### PR TITLE
Update elm-html-in-elm dependency to accept version 2 or 3

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "ElmHtml.Query"
     ],
     "dependencies": {
-        "eeue56/elm-html-in-elm": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-html-in-elm": "2.0.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },


### PR DESCRIPTION
The code compiles with no problems for both versions.
This change is necessary so I can continue to work on [PR #15 on elm-html-test](https://github.com/eeue56/elm-html-test/pull/15).